### PR TITLE
fix: skip premature attempt to compile

### DIFF
--- a/usautobuild/actions/builder.py
+++ b/usautobuild/actions/builder.py
@@ -138,6 +138,7 @@ class Builder:
     def generate_build_args(self, target: str) -> str:
         return (
             f"-nographics "
+            f"-ignoreCompilerErrors "
             f"-projectPath /root/UnityProject "
             f"-buildTarget {self.get_real_target(target)} "
             f"-executeMethod BuildScript.BuildProject "


### PR DESCRIPTION
this is needed because the project has a dependency on some nuget packages that aren't yet installed by the time editor tries to do the first compile.