### PR TITLE
improve log messages

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,15 @@
 import logging
 
-from usautobuild.actions import ApiCaller, Builder, Dockerizer, Gitter, Licenser, Uploader, DiscordChangelogPoster, tag_as_stable
+from usautobuild.actions import (
+    ApiCaller,
+    Builder,
+    DiscordChangelogPoster,
+    Dockerizer,
+    Gitter,
+    Licenser,
+    Uploader,
+    tag_as_stable,
+)
 from usautobuild.cli import args
 from usautobuild.config import Config
 from usautobuild.logger import Logger

--- a/usautobuild/actions/__init__.py
+++ b/usautobuild/actions/__init__.py
@@ -1,11 +1,11 @@
 from .api_caller import ApiCaller
 from .builder import Builder
+from .discord_changelog_poster import DiscordChangelogPoster
 from .dockerizer import Dockerizer
 from .gitter import Gitter
 from .licenser import Licenser
-from .uploader import Uploader
-from .discord_changelog_poster import DiscordChangelogPoster
 from .stable_tagger import tag_as_stable
+from .uploader import Uploader
 
 __all__ = (
     "ApiCaller",

--- a/usautobuild/actions/builder.py
+++ b/usautobuild/actions/builder.py
@@ -196,6 +196,6 @@ class Builder:
                     log.error("Abort: %s", e)
                     raise
             finally:
-                log.info("Built %s in %s", target, humanize.naturaltime(time.time() - start_target))
+                log.info("%s duration: %s", target, humanize.naturaltime(time.time() - start_target))
 
         log.info("Finished building in %s", humanize.naturaltime(time.time() - start))

--- a/usautobuild/actions/builder.py
+++ b/usautobuild/actions/builder.py
@@ -6,6 +6,8 @@ import time
 from logging import getLogger
 from pathlib import Path
 
+import humanize
+
 from usautobuild.config import Config
 from usautobuild.exceptions import BuildFailed, InvalidProjectPath, MissingLicenseFile, NugetRestoreFailed
 from usautobuild.utils import git_version, run_process_shell
@@ -173,8 +175,8 @@ class Builder:
             raise NugetRestoreFailed(self.config.project_path)
 
     def start_building(self) -> None:
-        log.info("Starting a new build: %s", git_version(directory=self.config.project_path, brief=False))
-        time_building_start = time.time()
+        log.info("Building version: %s", git_version(directory=self.config.project_path, brief=False))
+        start = time.time()
 
         self.check_license()
         self.clean_builds_folder()
@@ -184,20 +186,16 @@ class Builder:
         self.restore_nuget_packages()
 
         for target in self.config.target_platforms:
-            log.debug(f"Starting build for {target}...")
-            time_target = time.time()
+            log.debug("Building %s", target)
 
+            start_target = time.time()
             try:
                 self.build(target)
-            except BuildFailed:
+            except Exception as e:
                 if self.config.abort_on_build_fail:
-                    time_final_target = time.time() - time_target
-                    time_final_build = time.time() - time_building_start
-                    log.error(f"Build for {target} failed and config is set to abort on fail!\n Build Time Took: {time_final_target:.2f}.\n Total Time Took: {time_final_build:.2f}")
+                    log.error("Abort: %s", e)
                     raise
-            else:
-                time_final_build = time.time() - time_target
-                log.info(f"Finished build for {target}. Time took: {time_final_build:.2f}")
+            finally:
+                log.info("Built %s in %s", target, humanize.naturaltime(time.time() - start_target))
 
-        time_building_final = time.time() - time_building_start
-        log.info(f"Finished building!\nTotal Time Took: {time_building_final:.2f}")
+        log.info("Finished building in %s", humanize.naturaltime(time.time() - start))

--- a/usautobuild/actions/discord_changelog_poster.py
+++ b/usautobuild/actions/discord_changelog_poster.py
@@ -3,8 +3,9 @@ from dataclasses import dataclass
 from logging import getLogger
 from typing import DefaultDict
 
-from usautobuild.config import Config
 import requests
+
+from usautobuild.config import Config
 
 log = getLogger("usautobuild")
 
@@ -66,7 +67,7 @@ def format_changelog(prs: list[Pr], build: str) -> str:
 
 
 def format_change(change: ChangeModel) -> str:
-    emoji = category_to_emoji.get(change.category, ':question:')
+    emoji = category_to_emoji.get(change.category, ":question:")
     return f"- {emoji} {change.description}"
 
 
@@ -76,20 +77,20 @@ class DiscordChangelogPoster:
         self.newest_build_url = config.newest_build_api_url
 
     def post_changelog(self, message: str):
-        message_chunks = [message[i:i + 2000] for i in range(0, len(message), 2000)]
+        message_chunks = [message[i : i + 2000] for i in range(0, len(message), 2000)]
 
         for chunk in message_chunks:
             wh_data = {
                 "content": chunk,
                 # disallow any pings
-                "allowed_mentions": {"parse": []}
+                "allowed_mentions": {"parse": []},
             }
 
             response = requests.post(self.changelog_webhook, json=wh_data)
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError as e:
-                log.error(f"Failed to post new build to the changelog webhook. See console for more information.")
+                log.error("Failed to post new build to the changelog webhook. See console for more information.")
                 print(f"Failed to post new build to the changelog webhook: {e}")
                 log.error(response.json())
                 raise
@@ -117,7 +118,7 @@ class DiscordChangelogPoster:
                     date_added=change["date_added"],
                 )
                 for change in data["changes"]
-            ]
+            ],
         )
 
     def start_posting(self):

--- a/usautobuild/actions/dockerizer.py
+++ b/usautobuild/actions/dockerizer.py
@@ -63,6 +63,4 @@ class Dockerizer:
         self.copy_server_build()
         self.make_images()
         self.push_images()
-        log.info(
-            "Process finished, a new staging build has been deployed and should " "shortly be present on the server."
-        )
+        log.info("Process finished, a new staging build has been deployed and should shortly be present on the server.")

--- a/usautobuild/actions/stable_tagger.py
+++ b/usautobuild/actions/stable_tagger.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+
 from usautobuild.utils import run_process_shell
 
 log = getLogger("usautobuild")
@@ -7,10 +8,7 @@ log = getLogger("usautobuild")
 def tag_as_stable():
     log.info("Pushing a stable build from the latest build!")
 
-    if status := run_process_shell(
-        f"docker build "
-        f"-t unitystation/unitystation:stable Docker"
-    ):
+    if status := run_process_shell("docker build -t unitystation/unitystation:stable Docker"):
         raise Exception(f"Build failed: {status}")
 
     if status := run_process_shell(
@@ -20,7 +18,5 @@ def tag_as_stable():
     ):
         raise Exception(f"Docker login failed: {status}")
 
-    if status := run_process_shell(
-        f"docker push unitystation/unitystation:stable"
-    ):
+    if status := run_process_shell("docker push unitystation/unitystation:stable"):
         raise Exception(f"Push failed: {status}")

--- a/usautobuild/exceptions.py
+++ b/usautobuild/exceptions.py
@@ -28,6 +28,7 @@ class NugetRestoreFailed(BaseException):
     def __init__(self, path: Path) -> None:
         super().__init__(f"Nuget restore failed in {path}! Is the path invalid or is NugetForUnity not installed?")
 
+
 class MissingLicenseFile(BaseException):
     def __init__(self, path: Path) -> None:
         super().__init__(f"License file couldn't be found in set directory {path}")

--- a/usautobuild/utils.py
+++ b/usautobuild/utils.py
@@ -132,6 +132,6 @@ def git_version(directory: Optional[Path] = None, brief: bool = True) -> str:
     if not brief:
         time_delta = datetime.now(tz=last_commit.committed_datetime.tzinfo) - last_commit.committed_datetime
 
-        version += f" by {last_commit.author} {humanize.naturaltime(time_delta)}: {str(last_commit.summary)}"
+        version += f" from {humanize.naturaltime(time_delta)} by {last_commit.author}: {str(last_commit.summary)}"
 
     return version


### PR DESCRIPTION
improved messages for build times and build version at start. Unrelated formatting changes because files were not formatted properly or had flake8 errors.

Main change is using humanize.naturaldelta instead of displaying seconds as float